### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -18,6 +18,9 @@ class ProductsController < ApplicationController
     end
   end
 
+  def show
+  end
+
   private
 
   def product_params

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -19,6 +19,7 @@ class ProductsController < ApplicationController
   end
 
   def show
+    @product = Product.find(params[:id])
   end
 
   private

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -121,7 +121,7 @@
       <% if @products.present? %>
       <% @products.each do |product| %>
         <li class='list'>
-         <%= link_to "#" do %>
+         <%= link_to  product_path(product.id), method: :get %>
         <div class='item-img-content'>
           <%= image_tag product.image, class: "item-img" if product.image.attached? %>
           <div class='sold-out'>
@@ -141,7 +141,6 @@
             </div>
           </div>
         </div>
-        <% end %>
         </li>
       <%end%>
      

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -121,9 +121,8 @@
       <% if @products.present? %>
       <% @products.each do |product| %>
         <li class='list'>
-         <%= link_to  product_path(product.id), method: :get %>
         <div class='item-img-content'>
-          <%= image_tag product.image, class: "item-img" if product.image.attached? %>
+          <%= link_to image_tag(product.image, class: "item-img" ) , product_path(product.id)%>
           <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -43,7 +43,7 @@
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= @product.seller.nickname %></td>
+          <td class="detail-value"><%= @product.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -24,16 +24,15 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? && current_user.id == @product.user_id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
-
+    <%elsif user_signed_in? %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+  <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
-
-
+  <%end%>
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -4,10 +4,10 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @product.product_name %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @product.image, class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -16,10 +16,10 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @product.price%>円
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @product.shipping_charge.name %>
       </span>
     </div>
 
@@ -37,33 +37,33 @@
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @product.product_explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @product.seller.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @product.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @product.product_status.name%></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @product.shipping_charge.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @product.shipping_area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @product.ship.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -1,6 +1,5 @@
 <%= render "shared/header" %>
 
-<%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
@@ -8,11 +7,9 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @product.image, class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
       </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -23,17 +20,13 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? && current_user.id == @product.user_id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
     <%elsif user_signed_in? %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
   <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
   <%end%>
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @product.product_explanation %></span>
@@ -77,7 +70,6 @@
       </div>
     </div>
   </div>
-  <%# /商品の概要 %>
 
   <div class="comment-box">
     <form>
@@ -101,9 +93,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @product.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'products#index'
-  resources :products, only: [:new, :create, :syow]
+  resources :products, only: [:new, :create, :show]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'products#index'
-  resources :products, only: [:new, :create]
+  resources :products, only: [:new, :create, :syow]
 end


### PR DESCRIPTION
# what
商品詳細表示の実装

# why
商品詳細ページが必要なため

# URL
ログイン状態かつ、自身が出品した販売中の商品詳細ページに遷移した動画
https://gyazo.com/46ef6b199429d31bc24a521b8f427259

ログイン状態かつ、自身が出品していない販売中の商品詳細ページへの遷移した動画
https://gyazo.com/9edc37e4446070d0a5ed9c26063a06a8

ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/5908ca0f7bb3dcaab013bc88614ab789

（商品購入機能実装前なので”sould out”などが表示されています。）